### PR TITLE
build(release): R8 난독화 설정 추가

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -18,4 +18,8 @@
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+#-renamesourcefileattribute SourceFile 
+
+-dontwarn com.wiseduck.squadbuilder.core.designsystem.theme.ThemeKt
+-dontwarn com.wiseduck.squadbuilder.feature.main.MainActivity_GeneratedInjector
+-dontwarn com.wiseduck.squadbuilder.feature.screens.LoginScreen

--- a/feature/main/proguard-rules.pro
+++ b/feature/main/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-dontwarn com.wiseduck.squadbuilder.core.designsystem.theme.ThemeKt
+-dontwarn com.wiseduck.squadbuilder.feature.screens.LoginScreen


### PR DESCRIPTION
- 릴리즈 빌드 시, R8이 필수 클래스를 제거하는 오류 해결