### PR TITLE
fix: Service Account 키 파일 파싱 오류 해결 (#21)

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -88,7 +88,7 @@ jobs:
           path: app/build/outputs/bundle/release/
 
       - name: Create service_account.json
-        run: echo '${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}' > service_account.json
+        run: echo '${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}' | base64 -d > service_account.json
 
       - name: Create whatsNewDirectory
         run: |


### PR DESCRIPTION
- 시크릿 키를 인코딩하여 저장한 것에 맞춰 디코딩을 수행하도록 수정