### PR TITLE
fix: 쿼터 1개만 선택했을 때 이미지 공유가 실패하는 이슈를 해결한다

### DIFF
--- a/feature/edit/src/main/java/com/wiseduck/squadbuilder/feature/edit/formation/FormationPresenter.kt
+++ b/feature/edit/src/main/java/com/wiseduck/squadbuilder/feature/edit/formation/FormationPresenter.kt
@@ -1,6 +1,7 @@
 package com.wiseduck.squadbuilder.feature.edit.formation
 
 import android.net.Uri
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -153,6 +154,7 @@ class FormationPresenter @AssistedInject constructor(
                 val urisToSend = sharingQuarters.mapNotNull { capturedUris[it] }
 
                 if (urisToSend.size == totalQuartersToCapture && urisToSend.isNotEmpty()) {
+                    Log.d("SHARE_IMAGE", "handleCaptureComplete: $urisToSend")
                     sideEffect = FormationSideEffect.ShareMultipleImages(urisToSend)
                 } else {
                     toastMessage = multipleShareCaptureError
@@ -171,6 +173,7 @@ class FormationPresenter @AssistedInject constructor(
                     val quarterList = event.quarters.sorted().toList()
 
                     if (quarterList.isNotEmpty()) {
+                        Log.d("SHARE_IMAGE", "handleEvent: $quarterList")
                         sharingQuarters = quarterList
                         totalQuartersToCapture = quarterList.size
                         capturedUris = emptyMap()


### PR DESCRIPTION
- 단일 쿼터 (1개): ACTION_SEND 사용
- 복수 쿼터 (2개 이상): ACTION_SEND_MULTIPLE 사용