### PR TITLE
build(ci): GitHub Actions 빌드 캐시를 적용한다

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -22,6 +22,23 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
+      - name: Cache Gradle Wrapper
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-wrapper-
+
+      - name: Cache Build Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches/build-cache-1
+          key: ${{ runner.os }}-build-cache-${{ hashFiles('**/build.gradle*', '**/gradle-wrapper.properties') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-build-cache-${{ hashFiles('**/build.gradle*', '**/gradle-wrapper.properties') }}
+            ${{ runner.os }}-build-cache-
+
       - name: Generate local.properties
         run: echo '${{ secrets.LOCAL_PROPERTIES }}' | base64 -d > ./local.properties
 
@@ -38,4 +55,4 @@ jobs:
         run: ./gradlew ktlintCheck detekt
 
       - name: Debug Build with Gradle
-        run: ./gradlew buildDebug --stacktrace
+        run: ./gradlew buildDebug --stacktrace --build-cache


### PR DESCRIPTION
- Gradle Wrapper 및 Build Cache를 actions/cache@v4를 사용하여 캐싱하도록 설정
- 히트율을 높이기 위해 key에 OS, 프로젝트 해시(build.gradle.kts), 그리고 현재 브랜치/커밋 해시를 포함하여 엄격하게 검사하도록 설정
- --build-cache 옵션을 명시적으로 추가