### PR TITLE
feat: Firebase Analytics 사용을 위한 환경을 구축한다

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -14,3 +14,12 @@ android {
         buildConfigField("String", "PACKAGE_NAME", "\"${libs.versions.applicationId.get()}\"")
     }
 }
+
+ksp {
+    arg("circuit.codegen.mode", "hilt")
+}
+
+dependencies {
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.analytics)
+}

--- a/core/common/src/main/java/com/wiseduck/squadbuilder/core/common/analytics/AnalyticsService.kt
+++ b/core/common/src/main/java/com/wiseduck/squadbuilder/core/common/analytics/AnalyticsService.kt
@@ -1,0 +1,26 @@
+package com.wiseduck.squadbuilder.core.common.analytics
+
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.logEvent
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AnalyticsService @Inject constructor(
+    private val firebaseAnalytics: FirebaseAnalytics,
+) {
+
+    fun logEvent(eventName: String, params: Map<String, Any>) {
+        firebaseAnalytics.logEvent(eventName) {
+            params.forEach { (key, value) ->
+                when (value) {
+                    is String -> param(key, value)
+                    is Int -> param(key, value.toLong())
+                    is Long -> param(key, value)
+                    is Double -> param(key, value)
+                    else -> param(key, value.toString())
+                }
+            }
+        }
+    }
+}

--- a/core/common/src/main/java/com/wiseduck/squadbuilder/core/common/analytics/di/AnalyticsModule.kt
+++ b/core/common/src/main/java/com/wiseduck/squadbuilder/core/common/analytics/di/AnalyticsModule.kt
@@ -1,0 +1,21 @@
+package com.wiseduck.squadbuilder.core.common.analytics.di
+
+import com.google.firebase.Firebase
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.analytics
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AnalyticsModule {
+
+    @Provides
+    @Singleton
+    fun provideFirebaseAnalytics(): FirebaseAnalytics {
+        return Firebase.analytics
+    }
+}


### PR DESCRIPTION
- 공통 모듈에 Firebase 컨벤션 플러그인을 추가하는 대신 필요한 analytics 라이브러리만 추가
- 다른 모듈에서 서비스를 사용할 수 있도록 DI 설정
- logEvent() 메서드 구현

참고:
- https://firebase.google.com/docs/analytics/get-started?platform=android&hl=ko&_gl=1*rta0xs*_up*MQ..*_ga*MjA3Mzc5MzM4My4xNzY0NjY0MDk5*_ga_CW55HF8NVT*czE3NjQ2NjQwOTkkbzEkZzAkdDE3NjQ2NjQwOTkkajYwJGwwJGgw