### PR TITLE
refactor(splash): Implement side effect for play store navigation

### DIFF
--- a/feature/splash/src/main/java/com/wiseduck/squadbuilder/feature/splash/HandleSplashSideEffect.kt
+++ b/feature/splash/src/main/java/com/wiseduck/squadbuilder/feature/splash/HandleSplashSideEffect.kt
@@ -1,0 +1,26 @@
+package com.wiseduck.squadbuilder.feature.splash
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import com.wiseduck.squadbuilder.core.common.extensions.goToPlayStore
+
+@Composable
+fun HandleSplashSideEffect(
+    state: SplashUiState,
+    eventSink: (SplashUiEvent) -> Unit,
+) {
+    val context = LocalContext.current
+
+    LaunchedEffect(state.sideEffect) {
+        val effect = state.sideEffect ?: return@LaunchedEffect
+
+        when (effect) {
+            SplashSideEffect.OnUpdateClick -> {
+                context.goToPlayStore()
+            }
+        }
+
+        eventSink(SplashUiEvent.InitSideEffect)
+    }
+}

--- a/feature/splash/src/main/java/com/wiseduck/squadbuilder/feature/splash/SplashPresenter.kt
+++ b/feature/splash/src/main/java/com/wiseduck/squadbuilder/feature/splash/SplashPresenter.kt
@@ -8,12 +8,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.retained.collectAsRetainedState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
-import com.wiseduck.squadbuilder.core.common.extensions.goToPlayStore
 import com.wiseduck.squadbuilder.core.data.api.repository.RemoteConfigRepository
 import com.wiseduck.squadbuilder.core.data.api.repository.UserRepository
 import com.wiseduck.squadbuilder.core.model.OnboardingState
@@ -42,20 +40,22 @@ class SplashPresenter @AssistedInject constructor(
     @Composable
     override fun present(): SplashUiState {
         val scope = rememberCoroutineScope()
-        val context = LocalContext.current
+        var sideEffect by remember { mutableStateOf<SplashSideEffect?>(null) }
         val onboardingState by userRepository.onboardingState.collectAsRetainedState(OnboardingState.NOT_YET)
         var isUpdateDialogVisible by remember { mutableStateOf(false) }
 
         fun handleEvent(event: SplashUiEvent) {
             when (event) {
+                SplashUiEvent.InitSideEffect -> {
+                    sideEffect = null
+                }
+
                 SplashUiEvent.OnCloseDialogButtonClick -> {
                     isUpdateDialogVisible = false
                 }
 
                 SplashUiEvent.OnUpdateButtonClick -> {
-                    scope.launch {
-                        context.goToPlayStore()
-                    }
+                    sideEffect = SplashSideEffect.OnUpdateClick
                 }
             }
         }
@@ -96,6 +96,7 @@ class SplashPresenter @AssistedInject constructor(
 
         return SplashUiState(
             isUpdateDialogVisible = isUpdateDialogVisible,
+            sideEffect = sideEffect,
             eventSink = ::handleEvent,
         )
     }

--- a/feature/splash/src/main/java/com/wiseduck/squadbuilder/feature/splash/SplashUi.kt
+++ b/feature/splash/src/main/java/com/wiseduck/squadbuilder/feature/splash/SplashUi.kt
@@ -31,6 +31,11 @@ fun SplashUi(
     modifier: Modifier = Modifier,
     state: SplashUiState,
 ) {
+    HandleSplashSideEffect(
+        state = state,
+        eventSink = state.eventSink,
+    )
+
     Box(
         modifier = modifier
             .fillMaxSize()

--- a/feature/splash/src/main/java/com/wiseduck/squadbuilder/feature/splash/SplashUiState.kt
+++ b/feature/splash/src/main/java/com/wiseduck/squadbuilder/feature/splash/SplashUiState.kt
@@ -1,15 +1,24 @@
 package com.wiseduck.squadbuilder.feature.splash
 
+import androidx.compose.runtime.Immutable
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 
 data class SplashUiState(
     val isLoading: Boolean = false,
     val isUpdateDialogVisible: Boolean = false,
+    val sideEffect: SplashSideEffect? = null,
     val eventSink: (SplashUiEvent) -> Unit,
 ) : CircuitUiState
 
+@Immutable
+sealed interface SplashSideEffect {
+    data object OnUpdateClick : SplashSideEffect
+}
+
 sealed interface SplashUiEvent : CircuitUiEvent {
+    data object InitSideEffect : SplashUiEvent
+
     data object OnCloseDialogButtonClick : SplashUiEvent
 
     data object OnUpdateButtonClick : SplashUiEvent

--- a/feature/splash/stability/splash.stability
+++ b/feature/splash/stability/splash.stability
@@ -5,6 +5,14 @@
 //   ./gradlew :splash:stabilityDump
 
 @Composable
+public fun com.wiseduck.squadbuilder.feature.splash.HandleSplashSideEffect(state: com.wiseduck.squadbuilder.feature.splash.SplashUiState, eventSink: kotlin.Function1<com.wiseduck.squadbuilder.feature.splash.SplashUiEvent, kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - state: STABLE (class with no mutable properties)
+    - eventSink: STABLE (function type)
+
+@Composable
 public fun com.wiseduck.squadbuilder.feature.splash.SplashPresenter.present(): com.wiseduck.squadbuilder.feature.splash.SplashUiState
   skippable: true
   restartable: true


### PR DESCRIPTION
- Move Play Store navigation logic from SplashPresenter to HandleSplashSideEffect.
- Remove LocalContext dependency from SplashPresenter.